### PR TITLE
enable line commenting in wisl and fix wisl lemmas grammar

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,5 +1,6 @@
 {
     "comments": {
+        "lineComment": "//",
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
         "blockComment": [ "(*", "*)" ]
     },

--- a/syntaxes/wisl.tmLanguage.json
+++ b/syntaxes/wisl.tmLanguage.json
@@ -69,7 +69,7 @@
       ]
     },
     "lemmas": {
-      "begin": "(?=(?:\\s*)(?:\\s*)?\\b(lemma)\\b(?:\\s*)([a-zA-Z][a-zA-Z_]*)\\b(?:\\s*))",
+      "begin": "(?=(?:\\s*)(?:\\s*)?\\b(lemma)\\b(?:\\s*)([a-zA-Z][a-zA-Z_]*)\\b)",
       "end": "(?<=})",
       "name": "meta.lemma.wisl",
       "patterns": [
@@ -77,16 +77,10 @@
           "include": "#comments"
         },
         {
-          "include": "#lemma_body"
+          "include": "#lemma_innards"
         },
         {
-          "begin": "\\G",
-          "end": "(?<=\\s)",
-          "patterns": [
-            {
-              "include": "#lemma_innards"
-            }
-          ]
+          "include": "#lemma_body"
         }
       ]
     },

--- a/syntaxes/wisl.tmLanguage.json
+++ b/syntaxes/wisl.tmLanguage.json
@@ -9,6 +9,9 @@
       "include": "#functions"
     },
     {
+      "include": "#lemmas"
+    },
+    {
       "include": "#comments"
     },
     {
@@ -50,7 +53,7 @@
     "lemma_innards": {
       "patterns": [
         {
-          "match": "(?:\\s*)?\\blemma\\b(?:\\s*)([a-zA-Z][a-zA-Z_]*)\\b(?=\\s*)",
+          "match": "(?:\\s*)?\\b(lemma)\\b(?:\\s*)([a-zA-Z][a-zA-Z_]*)\\b",
           "captures": {
             "1": {
               "name": "storage.type.lemma.wisl"
@@ -66,7 +69,7 @@
       ]
     },
     "lemmas": {
-      "begin": "(?=(?:\\s*)?\\blemma\\b(?:\\s*)([a-zA-Z][a-zA-Z_]*)\\b(?:\\s*)",
+      "begin": "(?=(?:\\s*)(?:\\s*)?\\b(lemma)\\b(?:\\s*)([a-zA-Z][a-zA-Z_]*)\\b(?:\\s*))",
       "end": "(?<=})",
       "name": "meta.lemma.wisl",
       "patterns": [
@@ -78,7 +81,7 @@
         },
         {
           "begin": "\\G",
-          "end": "(?=\\s*{)",
+          "end": "(?<=\\s)",
           "patterns": [
             {
               "include": "#lemma_innards"
@@ -537,7 +540,7 @@
           "name": "variable.program.wisl"
         },
         {
-          "match": "#[a-zA-Z][a-zA-Z_]*\\b",
+          "match": "#[a-zA-Z][a-zA-Z0-9]*\\b",
           "name": "variable.logical.wisl"
         }
       ]


### PR DESCRIPTION
- Allows line commenting using double-slash

- fix lemma grammar in wisltmLanguage (tokenise correctly)

- Allow logical variable with numeric values
